### PR TITLE
Upgrade to BoaviztAPI SDK 1.2.4

### DIFF
--- a/boagent/api/__init__.py
+++ b/boagent/api/__init__.py
@@ -1,1 +1,6 @@
-from .api import build_hardware_data, read_hardware_data, get_hardware_data
+from .api import (
+    build_hardware_data,
+    read_hardware_data,
+    get_hardware_data,
+    query_machine_impact_data,
+)

--- a/boagent/api/api.py
+++ b/boagent/api/api.py
@@ -627,6 +627,7 @@ def query_machine_impact_data(
         )
     elif model:
         # server = Server(usage=usage, model=model)
+        # TO IMPLEMENT
         # This conditional was based on a previous version of BoaviztAPI, where a server model could
         # be sent to /v1/server through a GET method. BoaviztAPI now expects an archetype string to
         # return a prerecorded impact from an asset.
@@ -638,6 +639,7 @@ def query_machine_impact_data(
 
 
 def generate_machine_configuration(hardware_data) -> Dict[str, Any]:
+    # Either delete or transfer this logic to hardware_cli / lshw
     config = {
         "cpu": {
             "units": len(hardware_data["cpus"]),

--- a/boagent/api/api.py
+++ b/boagent/api/api.py
@@ -14,7 +14,6 @@ from fastapi import FastAPI, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import HTMLResponse
 from boaviztapi_sdk.api.server_api import ServerApi
-from boaviztapi_sdk.model.server_dto import ServerDTO
 from utils import (
     iso8601_or_timestamp_as_timestamp,
     format_scaphandre_json,
@@ -23,6 +22,8 @@ from utils import (
     sort_ram,
     sort_disks,
 )
+from boaviztapi_sdk.models.server import Server
+
 from config import settings
 from database import (
     get_session,
@@ -620,14 +621,17 @@ def query_machine_impact_data(
     server_impact = None
 
     if configuration:
-        server_dto = ServerDTO(usage=usage, configuration=configuration)
-        server_impact = server_api.server_impact_by_config_v1_server_post(
-            server_dto=server_dto
+        server = Server(usage=usage, configuration=configuration)
+        server_impact = server_api.server_impact_from_configuration_v1_server_post(
+            server=server
         )
     elif model:
-        server_dto = ServerDTO(usage=usage, model=model)
-        server_impact = server_api.server_impact_by_model_v1_server_get(
-            server_dto=server_dto
+        # server = Server(usage=usage, model=model)
+        # This conditional was based on a previous version of BoaviztAPI, where a server model could
+        # be sent to /v1/server through a GET method. BoaviztAPI now expects an archetype string to
+        # return a prerecorded impact from an asset.
+        server_impact = server_api.server_impact_from_model_v1_server_get(
+            archetype="dellR740"
         )
 
     return server_impact

--- a/boagent/api/config.py
+++ b/boagent/api/config.py
@@ -1,4 +1,4 @@
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 import os
 
 

--- a/boagent/api/config.py
+++ b/boagent/api/config.py
@@ -34,7 +34,7 @@ class Settings(BaseSettings):
     carbon_aware_api_endpoint: str = os.getenv(
         "CARBON_AWARE_API_ENDPOINT", "https://carbon-aware-api.azurewebsites.net"
     )
-    carbon_aware_api_token: str = os.getenv("CARBON_AWARE_API_TOKEN")
+    carbon_aware_api_token: str = os.getenv("CARBON_AWARE_API_TOKEN", "token")
     azure_location: str = os.getenv("AZURE_LOCATION", "northeurope")
 
     class Config:

--- a/boagent/api/test_api_unit.py
+++ b/boagent/api/test_api_unit.py
@@ -1,7 +1,12 @@
 from unittest import TestCase
 from unittest.mock import patch
 
-from api import build_hardware_data, read_hardware_data, get_hardware_data
+from api import (
+    build_hardware_data,
+    read_hardware_data,
+    get_hardware_data,
+    query_machine_impact_data,
+)
 import os
 
 
@@ -32,10 +37,15 @@ class ApiUnitTest(TestCase):
         assert type(data) is dict
         mocked_build_hardware.assert_not_called()
 
-    def test_tead_get_hardware_data_with_fetch_hardware_true(self):
+    def test_read_get_hardware_data_with_fetch_hardware_true(self):
 
         data = get_hardware_data(fetch_hardware=True)
         assert type(data) is dict
+
+    def test_read_query_machine_impact_data(self):
+        server_impact = query_machine_impact_data()
+        print(server_impact)
+        pass
 
     def tearDown(self) -> None:
         os.remove("./hardware_data.json")

--- a/boagent/api/test_api_unit.py
+++ b/boagent/api/test_api_unit.py
@@ -15,11 +15,9 @@ class ApiUnitTest(TestCase):
 
         build_hardware_data()
         data = read_hardware_data()
-        assert type(data) is dict
-        assert type(data) is dict
-        assert type(data["cpu"]) is list
-        assert type(data["ram"]) is list
-        assert type(data["disk"]) is list
+        assert type(data["cpus"]) is list
+        assert type(data["rams"]) is list
+        assert type(data["disks"]) is list
 
     @patch("api.build_hardware_data")
     def test_read_get_hardware_data_with_fetch_hardware_false(

--- a/boagent/hardware/lshw/lshw.py
+++ b/boagent/hardware/lshw/lshw.py
@@ -210,6 +210,15 @@ class Lshw:
         split_model = model_string.split(" ")
         vendor = ""
 
+        if len(split_model) == 1:
+            check_string_for_numbers = bool(re.search("\\d", model_string))
+            if check_string_for_numbers:
+                raise Exception(
+                    "Lshw did not output an acceptable manufacturer name for this device."
+                )
+            else:
+                return model_string
+
         model_first_str = split_model[0]
         model_second_str = split_model[1]
         check_first_string_for_numbers = re.search("\\d", model_first_str)

--- a/boagent/tests/test_lshw.py
+++ b/boagent/tests/test_lshw.py
@@ -142,10 +142,12 @@ class LshwTest(TestCase):
         self, mocked_is_tool
     ):
 
-        with open(f"{mock_lshw_data}_disks.json", "r") as file:
+        with open(f"{mock_lshw_data}_disks.json", "r") as file, self.assertRaises(
+            Exception
+        ):
             mocked_is_tool.return_value = False
             data = load(file)
-            self.assertRaises(Exception, hw.find_storage(data))
+            hw.find_storage(data)
 
     def test_read_disks_manufacturer(self):
 

--- a/boagent/tests/test_lshw.py
+++ b/boagent/tests/test_lshw.py
@@ -144,10 +144,13 @@ class LshwTest(TestCase):
 
         with open(f"{mock_lshw_data}_disks.json", "r") as file, self.assertRaises(
             Exception
-        ):
+        ) as nvme_cli_exception:
             mocked_is_tool.return_value = False
             data = load(file)
             hw.find_storage(data)
+
+        caught_exception = nvme_cli_exception.exception
+        assert str(caught_exception) == "nvme-cli >= 1.0 does not seem to be installed"
 
     def test_read_disks_manufacturer(self):
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -i https://pypi.python.org/simple
 aiofile==3.8.1
 anyio==3.6.2 ; python_full_version >= '3.6.2'
-boaviztapi-sdk==0.1.2
+boaviztapi-sdk>=0.1.2
 caio==0.9.8 ; python_version >= '3.5' and python_version < '4'
 certifi==2022.9.24 ; python_version >= '3.6'
 charset-normalizer==2.1.1 ; python_full_version >= '3.6.0'
@@ -19,6 +19,7 @@ numpy==1.23.4 ; python_version < '3.10'
 pandas==1.5.1
 py-cpuinfo==9.0.0
 pydantic[dotenv]==1.10.2
+pydantic-settings==2.2.1
 pytest==8.0.2
 python-dateutil==2.8.2 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 python-dotenv==0.21.0


### PR DESCRIPTION

Upgrades to BoaviztAPI SDK 1.2.4. 

Reference to ServerDTO deleted in "query_machine_impact_data" in api module, now using Server class from BoaviztAPI SDK.
Current implementation of "query_machine_impact_data" through model needs work due to changes in BoaviztAPI => use an archetype
to get prerecorded impact of a server.

Closes #46.


- **refactor: update to BoaviztAPI Server class, update to pydantic-settings**
- **fix: format for carbon aware api token setting**
- **test: plural for data keys**
- **feat: conditional for model list of length 1**
- **test: raise exception as context manager for checking installation of nvme-cli**
- **docs: comments on change in BoaviztAPI SDK, on usage of generate_machine_configuration**
- **test: import for query_machine_impact_data**
- **test: refactor to show caught exception**
