### PR TITLE
Fixes for `Process` and `Lshw`

### DIFF
--- a/boagent/api/process.py
+++ b/boagent/api/process.py
@@ -67,16 +67,27 @@ class Process:
 
     def get_disk_usage_in_bytes(self):
 
-        disk_total_bytes = int(
-            self.metrics_data["raw_data"]["power_data"]["raw_data"][1]["host"][
-                "components"
-            ]["disks"][0]["disk_total_bytes"]
-        )
-        disk_available_bytes = int(
-            self.metrics_data["raw_data"]["power_data"]["raw_data"][1]["host"][
-                "components"
-            ]["disks"][0]["disk_available_bytes"]
-        )
+        # Data from Scaphandre can be empty on first returned element in the array
+        try:
+            key_for_disk_total_bytes = self.metrics_data["raw_data"]["power_data"][
+                "raw_data"
+            ][0]["host"]["components"]["disks"][0]["disk_total_bytes"]
+        except IndexError:
+            key_for_disk_total_bytes = self.metrics_data["raw_data"]["power_data"][
+                "raw_data"
+            ][1]["host"]["components"]["disks"][0]["disk_total_bytes"]
+
+        try:
+            key_for_disk_available_bytes = self.metrics_data["raw_data"]["power_data"][
+                "raw_data"
+            ][0]["host"]["components"]["disks"][0]["disk_available_bytes"]
+        except IndexError:
+            key_for_disk_available_bytes = self.metrics_data["raw_data"]["power_data"][
+                "raw_data"
+            ][1]["host"]["components"]["disks"][0]["disk_available_bytes"]
+
+        disk_total_bytes = int(key_for_disk_total_bytes)
+        disk_available_bytes = int(key_for_disk_available_bytes)
         disk_usage_in_bytes = disk_total_bytes - disk_available_bytes
         return disk_usage_in_bytes
 

--- a/boagent/hardware/lshw.py
+++ b/boagent/hardware/lshw.py
@@ -129,24 +129,25 @@ class Lshw:
                         "type": self.get_disk_type(device["logicalname"]),
                     }
                     self.disks.append(d)
-        if "nvme" in obj["configuration"]["driver"]:
-            if not is_tool("nvme"):
-                raise Exception("nvme-cli >= 1.0 does not seem to be installed")
-            try:
-                nvme = serialized_nvme_output()
-                for device in nvme["Devices"]:
-                    d = {
-                        "units": +1,
-                        "logicalname": device["DevicePath"],
-                        "manufacturer": self.check_disk_vendor(
-                            device["ModelNumber"]
-                        ).lower(),
-                        "type": "ssd",
-                        "capacity": device["PhysicalSize"] // 1073741824,
-                    }
-                    self.disks.append(d)
-            except Exception:
-                pass
+        if "configuration" in obj:
+            if "nvme" in obj["configuration"]["driver"]:
+                if not is_tool("nvme"):
+                    raise Exception("nvme-cli >= 1.0 does not seem to be installed")
+                try:
+                    nvme = serialized_nvme_output()
+                    for device in nvme["Devices"]:
+                        d = {
+                            "units": +1,
+                            "logicalname": device["DevicePath"],
+                            "manufacturer": self.check_disk_vendor(
+                                device["ModelNumber"]
+                            ).lower(),
+                            "type": "ssd",
+                            "capacity": device["PhysicalSize"] // 1073741824,
+                        }
+                        self.disks.append(d)
+                except Exception:
+                    pass
 
     def find_cpus(self, obj):
         if "product" in obj:


### PR DESCRIPTION
This pull request fixes two problems discovered while working with Boagent through Carenage:

- An `IndexError` in the method `get_disk_usage_in_bytes()` for the `Process` class when Scaphandre returns data in the first object of `raw_data`. 
- A `KeyError` in the method `find_storage()` for the `Lshw` class when `configuration` might not be an available key in the output from `lshw`. 
