### PR TITLE
Add Makefile with scripts for future releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+CURRENT_VERSION := $(shell poetry version -s)
+SEMVERS := major minor patch
+LAST_TAG := $(shell git describe --tags --abbrev=0)
+
+tag_version:
+	git commit -m "release: bump to ${CURRENT_VERSION}" pyproject.toml
+	git tag ${CURRENT_VERSION}
+
+$(SEMVERS):
+	poetry version $@
+	$(MAKE) tag_version
+
+release:
+	git push origin tag ${LAST_TAG}
+	gh release create --verify-tag ${LAST_TAG} --notes-from-tag

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "boagent"
-version = "0.1.0"
+version = "0.1.1"
 description = "Local API to collect and compute data on used device and running applications to give insight on their environmental impacts."
 authors = ["Boavizta <open-source@boavizta.org>"]
 license = "Apache-2.0"


### PR DESCRIPTION
This merge request adds a Makefile, which allows to use scripts to automatically bump the version of Boagent to the correct number (according to the semantic versioning put into place through Poetry).